### PR TITLE
 Add AOI-based HPC submission via shapefile input

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,16 @@ opensr-hpc submit patch \
   --start-date 2025-07-01 \
   --end-date 2025-07-03 \
   --dry-run
+
+opensr-hpc submit aoi \
+  --config deployment/configs/runtime.default.yaml \
+  --aoi-path /data/berlin_aoi \
+  --start-date 2025-07-01 \
+  --end-date 2025-07-03 \
+  --dry-run
 ```
 
-See `deployment/README.md` for the full run layout, config schema, and Slurm entrypoint details.
+See `deployment/README.md` for the full run layout, config schema, AOI settings, and Slurm entrypoint details.
 
 
 # 3. 🖼️ Super-Resolution Examples

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -5,7 +5,7 @@ This directory contains an installable Slurm launcher for running `opensr-model`
 ## What it does
 
 - stages Sentinel-2 cutouts with `cubo`
-- submits single-patch or grid runs through `sbatch`
+- submits single-patch, grid, or AOI runs through `sbatch`
 - runs `opensr-model` and `opensr-utils` on worker nodes
 - writes manifests, logs, metadata, and outputs into one run directory
 
@@ -37,12 +37,20 @@ opensr-hpc submit grid \
   --start-date 2025-07-01 \
   --end-date 2025-07-03 \
   --dry-run
+
+opensr-hpc submit aoi \
+  --config deployment/configs/runtime.default.yaml \
+  --aoi-path /data/berlin_aoi \
+  --start-date 2025-07-01 \
+  --end-date 2025-07-03 \
+  --dry-run
 ```
 
 ## Runtime configs
 
 - `deployment/configs/runtime.default.yaml` - baseline config
 - `deployment/configs/runtime.a100.example.yaml` - example GPU-node override
+- set `aoi.path` in the runtime config to define a default shapefile AOI
 
 ## Run layout
 
@@ -65,3 +73,4 @@ runs/<run_id>/
 - the bundled Slurm entrypoint is `deployment/opensr_hpc/slurm/slurm_task_entrypoint.sh`
 - default model config resolves to the packaged `opensr_model/configs/config_10m.yaml`
 - set `model.checkpoint_path` in the runtime config if you want to pin a local checkpoint
+- AOI submission accepts either a `.shp` file or a directory containing exactly one `.shp`; sidecar files like `.shx`, `.dbf`, and `.prj` must sit alongside it

--- a/deployment/configs/runtime.a100.example.yaml
+++ b/deployment/configs/runtime.a100.example.yaml
@@ -10,6 +10,10 @@ model:
   config_path: null
   checkpoint_path: null
 
+aoi:
+  path: null
+  layer: null
+
 staging:
   collection: "sentinel-2-l2a"
   bands: ["B04", "B03", "B02", "B08"]

--- a/deployment/configs/runtime.default.yaml
+++ b/deployment/configs/runtime.default.yaml
@@ -10,6 +10,10 @@ model:
   config_path: null
   checkpoint_path: null
 
+aoi:
+  path: null
+  layer: null
+
 staging:
   collection: "sentinel-2-l2a"
   bands: ["B04", "B03", "B02", "B08"]

--- a/deployment/configs/runtime.test.yaml
+++ b/deployment/configs/runtime.test.yaml
@@ -10,6 +10,10 @@ model:
   config_path: null
   checkpoint_path: null
 
+aoi:
+  path: null
+  layer: null
+
 staging:
   collection: "sentinel-2-l2a"
   bands: ["B04", "B03", "B02", "B08"]

--- a/deployment/opensr_hpc/aoi.py
+++ b/deployment/opensr_hpc/aoi.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import shapefile
+from pyproj import CRS, Transformer
+from shapely.geometry import box, shape
+from shapely.geometry.base import BaseGeometry
+from shapely.ops import transform, unary_union
+
+from deployment.opensr_hpc.patching import Patch, build_patches, meters_to_lat_deg, meters_to_lon_deg
+
+
+@dataclass(frozen=True, slots=True)
+class AoiSelection:
+    aoi_path: Path
+    aoi_layer: str | None
+    geometry: BaseGeometry
+    patches: list[Patch]
+
+
+def resolve_aoi_source_path(path: str | Path) -> Path:
+    source_path = Path(path).expanduser().resolve()
+    if not source_path.exists():
+        raise FileNotFoundError(f"AOI path not found: {source_path}")
+
+    if source_path.is_dir():
+        candidates = sorted(candidate for candidate in source_path.iterdir() if candidate.suffix.lower() == ".shp")
+        if not candidates:
+            raise ValueError(f"No .shp file found in AOI directory: {source_path}")
+        if len(candidates) > 1:
+            raise ValueError(f"Expected exactly one .shp file in AOI directory: {source_path}")
+        return candidates[0].resolve()
+
+    if source_path.suffix.lower() != ".shp":
+        raise ValueError(f"AOI path must be a .shp file or a directory containing one: {source_path}")
+    return source_path
+
+
+def _load_source_crs(shp_path: Path) -> CRS:
+    prj_path = shp_path.with_suffix(".prj")
+    if not prj_path.exists():
+        raise ValueError(f"AOI shapefile is missing .prj sidecar: {prj_path}")
+    prj_text = prj_path.read_text(encoding="utf-8").strip()
+    if not prj_text:
+        raise ValueError(f"AOI shapefile has an empty .prj sidecar: {prj_path}")
+    return CRS.from_user_input(prj_text)
+
+
+def load_aoi_geometry(path: str | Path) -> tuple[Path, BaseGeometry]:
+    shp_path = resolve_aoi_source_path(path)
+    source_crs = _load_source_crs(shp_path)
+
+    reader = shapefile.Reader(str(shp_path))
+    try:
+        geometries: list[BaseGeometry] = []
+        for record in reader.shapeRecords():
+            geom = shape(record.shape.__geo_interface__)
+            if geom.is_empty:
+                continue
+            if geom.geom_type not in {"Polygon", "MultiPolygon"}:
+                raise ValueError("AOI shapefile must contain polygon geometries")
+            geometries.append(geom)
+    finally:
+        reader.close()
+
+    if not geometries:
+        raise ValueError(f"AOI shapefile does not contain any polygon geometries: {shp_path}")
+
+    geometry = unary_union(geometries)
+    if geometry.is_empty:
+        raise ValueError(f"AOI shapefile geometry is empty after union: {shp_path}")
+
+    if source_crs != CRS.from_epsg(4326):
+        transformer = Transformer.from_crs(source_crs, CRS.from_epsg(4326), always_xy=True)
+        geometry = transform(transformer.transform, geometry)
+
+    if geometry.is_empty:
+        raise ValueError(f"AOI shapefile geometry is empty after reprojection: {shp_path}")
+    return shp_path, geometry
+
+
+def patch_footprint(patch: Patch, resolution_m: float) -> BaseGeometry:
+    patch_size_m = patch.edge_size * resolution_m
+    half_lat = meters_to_lat_deg(patch_size_m) / 2.0
+    half_lon = meters_to_lon_deg(patch_size_m, patch.latitude) / 2.0
+    return box(
+        patch.longitude - half_lon,
+        patch.latitude - half_lat,
+        patch.longitude + half_lon,
+        patch.latitude + half_lat,
+    )
+
+
+def select_aoi_patches(
+    *,
+    aoi_path: str | Path,
+    aoi_layer: str | None,
+    edge_size: int,
+    resolution_m: float,
+    overlap_meters: float,
+) -> AoiSelection:
+    resolved_path, geometry = load_aoi_geometry(aoi_path)
+    lat_min, lon_min, lat_max, lon_max = geometry.bounds[1], geometry.bounds[0], geometry.bounds[3], geometry.bounds[2]
+    patches = build_patches(lat_min, lon_min, lat_max, lon_max, edge_size, resolution_m, overlap_meters)
+    selected = [patch for patch in patches if patch_footprint(patch, resolution_m).intersects(geometry)]
+    if not selected:
+        raise ValueError(f"No SR cutouts intersect the AOI geometry: {resolved_path}")
+    return AoiSelection(aoi_path=resolved_path, aoi_layer=aoi_layer, geometry=geometry, patches=selected)

--- a/deployment/opensr_hpc/cli.py
+++ b/deployment/opensr_hpc/cli.py
@@ -199,8 +199,10 @@ def _handle_submit_aoi(args: argparse.Namespace) -> int:
 
 
 def _handle_run_task(args: argparse.Namespace) -> int:
+    from deployment.opensr_hpc.logging_utils import configure_logging
     from deployment.opensr_hpc.run_task import run_task
 
+    configure_logging()
     task_index = args.task_index
     if task_index is None and os.environ.get("SLURM_ARRAY_TASK_ID"):
         task_index = int(os.environ["SLURM_ARRAY_TASK_ID"])

--- a/deployment/opensr_hpc/cli.py
+++ b/deployment/opensr_hpc/cli.py
@@ -30,6 +30,11 @@ def build_parser() -> argparse.ArgumentParser:
     grid_parser.add_argument("--lat2", type=float, required=True)
     grid_parser.add_argument("--lon2", type=float, required=True)
 
+    aoi_parser = submit_subparsers.add_parser("aoi")
+    _add_submit_common_args(aoi_parser)
+    aoi_parser.add_argument("--aoi-path")
+    aoi_parser.add_argument("--layer")
+
     run_parser = subparsers.add_parser("run")
     run_subparsers = run_parser.add_subparsers(dest="run_command", required=True)
     task_parser = run_subparsers.add_parser("task")
@@ -59,6 +64,18 @@ def _resolve_script_path(script_path: str | None) -> Path:
     if script_path is None:
         return bundled_slurm_entrypoint().resolve()
     return Path(script_path).expanduser().resolve()
+
+
+def _log_multi_cutout_info(logger, patch_count: int, source_name: str) -> None:
+    if patch_count <= 1:
+        return
+    logger.info(
+        "%s uses multiple cubo cutouts (%d); cutouts overlap via staging.overlap_meters, "
+        "but overlapping SR outputs are not reconciled after inference, so downstream mosaics may show seams "
+        "at cutout boundaries",
+        source_name,
+        patch_count,
+    )
 
 
 def _handle_validate(args: argparse.Namespace) -> int:
@@ -117,13 +134,7 @@ def _handle_submit_grid(args: argparse.Namespace) -> int:
         float(config.staging.resolution),
         config.staging.overlap_meters,
     )
-    if len(patches) > 1:
-        logger.info(
-            "grid request uses multiple cubo cutouts (%d); cutouts overlap via staging.overlap_meters, "
-            "but overlapping SR outputs are not reconciled after inference, so downstream mosaics may show seams "
-            "at cutout boundaries",
-            len(patches),
-        )
+    _log_multi_cutout_info(logger, len(patches), "grid request")
     run_id, run_dir, submission = submit_grid_run(
         config=config,
         patches=patches,
@@ -134,6 +145,56 @@ def _handle_submit_grid(args: argparse.Namespace) -> int:
     )
     logger.info("submitted grid run_id=%s run_dir=%s patches=%d", run_id, run_dir, len(patches))
     print(json.dumps({"run_id": run_id, "run_dir": str(run_dir), "patches": len(patches), "submission": submission}, indent=2))
+    return 0
+
+
+def _handle_submit_aoi(args: argparse.Namespace) -> int:
+    from deployment.opensr_hpc.aoi import select_aoi_patches
+    from deployment.opensr_hpc.config import load_runtime_config
+    from deployment.opensr_hpc.logging_utils import configure_logging
+    from deployment.opensr_hpc.submit import submit_aoi_run
+
+    logger = configure_logging(verbose=args.verbose)
+    config = load_runtime_config(args.config)
+    aoi_path = args.aoi_path or config.aoi.path
+    if aoi_path is None:
+        raise ValueError("AOI path must be provided via --aoi-path or config.aoi.path")
+    aoi_layer = args.layer if args.layer is not None else config.aoi.layer
+    selection = select_aoi_patches(
+        aoi_path=aoi_path,
+        aoi_layer=aoi_layer,
+        edge_size=config.staging.edge_size,
+        resolution_m=float(config.staging.resolution),
+        overlap_meters=config.staging.overlap_meters,
+    )
+    _log_multi_cutout_info(logger, len(selection.patches), "AOI request")
+    run_id, run_dir, submission = submit_aoi_run(
+        config=config,
+        patches=selection.patches,
+        start_date=args.start_date,
+        end_date=args.end_date,
+        script_path=_resolve_script_path(args.script_path),
+        aoi_path=selection.aoi_path,
+        aoi_layer=selection.aoi_layer,
+        dry_run=args.dry_run,
+    )
+    logger.info(
+        "submitted aoi run_id=%s run_dir=%s patches=%d aoi_path=%s",
+        run_id,
+        run_dir,
+        len(selection.patches),
+        selection.aoi_path,
+    )
+    payload = {
+        "run_id": run_id,
+        "run_dir": str(run_dir),
+        "patches": len(selection.patches),
+        "aoi_path": str(selection.aoi_path),
+        "submission": submission,
+    }
+    if selection.aoi_layer is not None:
+        payload["aoi_layer"] = selection.aoi_layer
+    print(json.dumps(payload, indent=2))
     return 0
 
 
@@ -179,6 +240,8 @@ def main() -> int:
         return _handle_submit_patch(args)
     if args.command == "submit" and args.submit_command == "grid":
         return _handle_submit_grid(args)
+    if args.command == "submit" and args.submit_command == "aoi":
+        return _handle_submit_aoi(args)
     if args.command == "run" and args.run_command == "task":
         return _handle_run_task(args)
     if args.command == "collect":

--- a/deployment/opensr_hpc/config.py
+++ b/deployment/opensr_hpc/config.py
@@ -24,6 +24,12 @@ class ModelConfig:
 
 
 @dataclass(slots=True)
+class AoiConfig:
+    path: str | None = None
+    layer: str | None = None
+
+
+@dataclass(slots=True)
 class StagingConfig:
     collection: str = "sentinel-2-l2a"
     bands: list[str] = field(default_factory=lambda: ["B04", "B03", "B02", "B08"])
@@ -71,6 +77,7 @@ class RuntimeConfig:
     output_root: Path = Path("runs")
     environment: EnvironmentConfig = field(default_factory=EnvironmentConfig)
     model: ModelConfig = field(default_factory=ModelConfig)
+    aoi: AoiConfig = field(default_factory=AoiConfig)
     staging: StagingConfig = field(default_factory=StagingConfig)
     inference: InferenceConfig = field(default_factory=InferenceConfig)
     slurm: SlurmConfig = field(default_factory=SlurmConfig)
@@ -104,6 +111,7 @@ def _merge(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
 def _runtime_from_mapping(data: dict[str, Any]) -> RuntimeConfig:
     environment = EnvironmentConfig(**data.get("environment", {}))
     model = ModelConfig(**data.get("model", {}))
+    aoi = AoiConfig(**data.get("aoi", {}))
     staging = StagingConfig(**data.get("staging", {}))
     inference_data = dict(data.get("inference", {}))
     if "window_size" in inference_data:
@@ -116,6 +124,7 @@ def _runtime_from_mapping(data: dict[str, Any]) -> RuntimeConfig:
         output_root=output_root,
         environment=environment,
         model=model,
+        aoi=aoi,
         staging=staging,
         inference=inference,
         slurm=slurm,
@@ -155,6 +164,12 @@ def load_runtime_config(
             checkpoint_path = (base_dir / checkpoint_path).resolve()
         config.model.checkpoint_path = str(checkpoint_path)
 
+    if config.aoi.path is not None:
+        aoi_path = Path(config.aoi.path).expanduser()
+        if not aoi_path.is_absolute():
+            aoi_path = (base_dir / aoi_path).resolve()
+        config.aoi.path = str(aoi_path)
+
     validate_runtime_config(config)
     return config
 
@@ -180,6 +195,8 @@ def validate_runtime_config(config: RuntimeConfig) -> None:
         raise ValueError("slurm.mem_gb must be positive")
     if config.slurm.cpus_per_task <= 0:
         raise ValueError("slurm.cpus_per_task must be positive")
+    if config.aoi.path is not None and not Path(config.aoi.path).exists():
+        raise FileNotFoundError(f"AOI path not found: {config.aoi.path}")
 
     model_config_path = resolve_model_config_path(config)
     if not model_config_path.exists():

--- a/deployment/opensr_hpc/inference.py
+++ b/deployment/opensr_hpc/inference.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, cast
 
@@ -9,6 +10,9 @@ from omegaconf import OmegaConf
 from deployment.opensr_hpc.config import InferenceConfig
 from deployment.opensr_hpc.naming import patch_output_name
 from deployment.opensr_hpc.raster import compress_geotiff, compute_centroid_lat_lon
+
+
+LOGGER = logging.getLogger("opensr-hpc")
 
 
 def _build_runner(opensr_utils: Any, inference: InferenceConfig):
@@ -55,6 +59,13 @@ def run_inference(
         ) from exc
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
+    LOGGER.info(
+        "loading inference model input_tif=%s device=%s window_size=%s batch_size=%s",
+        input_tif,
+        device,
+        inference.window_size,
+        inference.batch_size,
+    )
     cfg = OmegaConf.load(model_config_path)
     if checkpoint_path is not None:
         cfg.ckpt_version = str(checkpoint_path)
@@ -76,6 +87,7 @@ def run_inference(
         save_preview=inference.save_preview,
         debug=False,
     )
+    LOGGER.info("inference finished for input_tif=%s", input_tif)
 
     final_sr_path = getattr(runner, "final_sr_path", None)
     if final_sr_path is None:
@@ -88,6 +100,7 @@ def run_inference(
 
     latitude, longitude = compute_centroid_lat_lon(final_sr_path)
     compressed_path = output_dir / patch_output_name(latitude, longitude)
+    LOGGER.info("compressing SR GeoTIFF input=%s output=%s", final_sr_path, compressed_path)
     compress_geotiff(final_sr_path, compressed_path)
     final_sr_path.unlink(missing_ok=True)
     return compressed_path

--- a/deployment/opensr_hpc/raster.py
+++ b/deployment/opensr_hpc/raster.py
@@ -32,9 +32,19 @@ def parse_epsg(text: str, lat: float, lon: float) -> int:
     return guess_utm_epsg(lat, lon)
 
 
+def _as_scalar(value: object) -> float:
+    if hasattr(value, "compute"):
+        value = value.compute()
+    return float(value)
+
+
 def scale_to_uint16(data: np.ndarray) -> np.ndarray:
-    if data.dtype.kind == "f" and np.nanmax(data) <= 1.1:
-        return np.clip(data * 10000.0, 0, 10000).astype("uint16")
+    if data.dtype.kind == "f":
+        finite_mask = np.isfinite(data)
+        safe_data = np.where(finite_mask, data, 0.0)
+        if _as_scalar(safe_data.max()) <= 1.1:
+            safe_data = safe_data * 10000.0
+        return np.clip(safe_data, 0, 10000).astype("uint16")
     return data.astype("uint16")
 
 

--- a/deployment/opensr_hpc/run_task.py
+++ b/deployment/opensr_hpc/run_task.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from deployment.opensr_hpc.checkpoint import resolve_checkpoint_path, sha256sum
@@ -8,6 +9,9 @@ from deployment.opensr_hpc.inference import run_inference
 from deployment.opensr_hpc.manifests import read_yaml, write_json
 from deployment.opensr_hpc.metadata import write_software_metadata
 from deployment.opensr_hpc.raster import raster_validity_stats
+
+
+LOGGER = logging.getLogger("opensr-hpc")
 
 
 def _resolve_patch_manifest(manifest_path: Path, task_index: int | None) -> dict:
@@ -39,9 +43,14 @@ def run_task(manifest_path: Path, task_index: int | None = None) -> Path | None:
     output_dir.mkdir(parents=True, exist_ok=True)
     metadata_dir.mkdir(parents=True, exist_ok=True)
     input_tif = _resolve_manifest_local_path(manifest_path, manifest["paths"]["input_tif"])
+    patch_id = str(manifest.get("patch_id", "unknown"))
+
+    LOGGER.info("starting worker task patch_id=%s manifest=%s", patch_id, manifest_path)
+    LOGGER.info("checking staged raster patch_id=%s input_tif=%s", patch_id, input_tif)
 
     validity = raster_validity_stats(input_tif)
     if validity["valid_pixels"] == 0 or validity["nonzero_pixels"] == 0:
+        LOGGER.info("skipping patch_id=%s because input raster is empty or all-zero stats=%s", patch_id, validity)
         write_json(
             metadata_dir / "result.json",
             {
@@ -65,6 +74,12 @@ def run_task(manifest_path: Path, task_index: int | None = None) -> Path | None:
     )
 
     checkpoint_path = resolve_checkpoint_path(config["model"]["checkpoint_path"])
+    LOGGER.info(
+        "running inference patch_id=%s input_tif=%s checkpoint=%s",
+        patch_id,
+        input_tif,
+        checkpoint_path if checkpoint_path is not None else "<default>",
+    )
     final_output = run_inference(
         input_tif=input_tif,
         output_dir=output_dir,
@@ -88,4 +103,5 @@ def run_task(manifest_path: Path, task_index: int | None = None) -> Path | None:
         },
     )
     write_software_metadata(metadata_dir / "software_env.json")
+    LOGGER.info("completed worker task patch_id=%s output=%s", patch_id, final_output)
     return final_output

--- a/deployment/opensr_hpc/staging.py
+++ b/deployment/opensr_hpc/staging.py
@@ -122,6 +122,14 @@ def stage_cutout(
     output_path: Path,
 ) -> Path:
     ensure_proj_env()
+    LOGGER.info(
+        "staging cubo cutout lat=%s lon=%s start_date=%s end_date=%s output=%s",
+        latitude,
+        longitude,
+        start_date,
+        end_date,
+        output_path,
+    )
     cube = create_cube_with_retry(
         latitude=latitude,
         longitude=longitude,
@@ -132,7 +140,8 @@ def stage_cutout(
     if "time" in cube.dims:
         cube = cube.isel(time=config.image_index)
     cube = cube.transpose("band", "y", "x")
-    ensure_cube_has_valid_data(cube)
+    stats = ensure_cube_has_valid_data(cube)
+    LOGGER.info("validated staged cutout lat=%s lon=%s stats=%s", latitude, longitude, stats)
 
     epsg_text = str(cube.attrs.get("epsg", "") or cube.coords.get("epsg", ""))
     epsg_code = parse_epsg(epsg_text, latitude, longitude)
@@ -151,4 +160,5 @@ def stage_cutout(
         blockysize=512,
         BIGTIFF="YES",
     )
+    LOGGER.info("wrote staged cutout lat=%s lon=%s output=%s", latitude, longitude, output_path)
     return output_path.resolve()

--- a/deployment/opensr_hpc/submit.py
+++ b/deployment/opensr_hpc/submit.py
@@ -160,14 +160,17 @@ def submit_patch_run(
     return run_id, run_dir, submission
 
 
-def submit_grid_run(
+def _submit_patch_collection(
     *,
+    mode: str,
     config: RuntimeConfig,
     patches: list[Patch],
     start_date: str,
     end_date: str,
     script_path: Path,
     dry_run: bool = False,
+    aoi_path: Path | None = None,
+    aoi_layer: str | None = None,
 ) -> tuple[str, Path, Mapping[str, object]]:
     run_id = new_run_id(config.project_name)
     run_dir = resolve_run_dir(config.output_root, run_id)
@@ -230,7 +233,7 @@ def submit_grid_run(
 
     run_manifest = {
         "run_id": run_id,
-        "mode": "grid",
+        "mode": mode,
         "patch_count": len(tasks),
         "start_date": start_date,
         "end_date": end_date,
@@ -241,6 +244,10 @@ def submit_grid_run(
         ],
         "skipped": skipped,
     }
+    if aoi_path is not None:
+        run_manifest["aoi_path"] = str(aoi_path)
+    if aoi_layer is not None:
+        run_manifest["aoi_layer"] = aoi_layer
     write_yaml(run_dir / "run_manifest.yaml", run_manifest)
 
     if not tasks:
@@ -258,3 +265,47 @@ def submit_grid_run(
     )
     submission = submit_job(spec, run_dir / "submission", dry_run=dry_run)
     return run_id, run_dir, submission
+
+
+def submit_grid_run(
+    *,
+    config: RuntimeConfig,
+    patches: list[Patch],
+    start_date: str,
+    end_date: str,
+    script_path: Path,
+    dry_run: bool = False,
+) -> tuple[str, Path, Mapping[str, object]]:
+    return _submit_patch_collection(
+        mode="grid",
+        config=config,
+        patches=patches,
+        start_date=start_date,
+        end_date=end_date,
+        script_path=script_path,
+        dry_run=dry_run,
+    )
+
+
+def submit_aoi_run(
+    *,
+    config: RuntimeConfig,
+    patches: list[Patch],
+    start_date: str,
+    end_date: str,
+    script_path: Path,
+    aoi_path: Path,
+    aoi_layer: str | None = None,
+    dry_run: bool = False,
+) -> tuple[str, Path, Mapping[str, object]]:
+    return _submit_patch_collection(
+        mode="aoi",
+        config=config,
+        patches=patches,
+        start_date=start_date,
+        end_date=end_date,
+        script_path=script_path,
+        dry_run=dry_run,
+        aoi_path=aoi_path,
+        aoi_layer=aoi_layer,
+    )

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,9 @@ setup(
         'hpc': [
             'PyYAML>=6.0',
             'pyproj>=3.4',
+            'pyshp>=2.3.1',
             'rioxarray>=0.15',
+            'shapely>=2.0.2',
             'cubo>=0.3',
             'opensr-utils>=1.0.0',
         ],


### PR DESCRIPTION
This PR adds AOI-driven submission to the HPC launcher. In addition to point and bbox-based runs, opensr-hpc can now ingest a shapefile AOI, generate the corresponding patch grid from its bounds, and keep only cutouts whose footprints intersect the AOI geometry.
The implementation is intentionally lightweight: it supports .shp input directly, or a folder containing exactly one shapefile dataset, and uses config-based AOI defaults with CLI override support. Run manifests now record AOI metadata for AOI submissions, while existing patch/grid flows remain unchanged.

### AOI Submission Support

* Added `AoiConfig` to runtime configuration and integrated AOI parameters (`path`, `layer`) in all config files and parsing logic. [[1]](diffhunk://#diff-bc11fa91119882d71492381f5d23a3d4a9a7dcad6836f159d6c4bf6163fa4e19R26-R31) [[2]](diffhunk://#diff-bc11fa91119882d71492381f5d23a3d4a9a7dcad6836f159d6c4bf6163fa4e19R80) [[3]](diffhunk://#diff-bc11fa91119882d71492381f5d23a3d4a9a7dcad6836f159d6c4bf6163fa4e19R114) [[4]](diffhunk://#diff-bc11fa91119882d71492381f5d23a3d4a9a7dcad6836f159d6c4bf6163fa4e19R127) [[5]](diffhunk://#diff-2c2bc5935e20ca024b73ba5d2f7d567f8f38d4616b9c15bd0bd2f7ae8d18c7ecR13-R16) [[6]](diffhunk://#diff-152556f1ddc316c1bd31d2f474928fcba8d33dd0649703c682e9667a528cf991R13-R16) [[7]](diffhunk://#diff-18facd43a953b7f16f619e9252def2e859a646f9790b2e38b87e138a418daaafR13-R16)
* Implemented AOI selection and patching logic in new module `deployment/opensr_hpc/aoi.py`, including geometry loading, CRS handling, and patch selection.
* Added CLI support for AOI submissions (`opensr-hpc submit aoi`) and integrated validation, patch selection, and run submission. [[1]](diffhunk://#diff-f0557534cfcdade4f18830d432c174e92ea158ac2ead79ee3684ccd5e6f99caaR33-R37) [[2]](diffhunk://#diff-f0557534cfcdade4f18830d432c174e92ea158ac2ead79ee3684ccd5e6f99caaR69-R80) [[3]](diffhunk://#diff-f0557534cfcdade4f18830d432c174e92ea158ac2ead79ee3684ccd5e6f99caaR151-R205) [[4]](diffhunk://#diff-f0557534cfcdade4f18830d432c174e92ea158ac2ead79ee3684ccd5e6f99caaR245-R246)

### Documentation Updates

* Updated `README.md` and `deployment/README.md` to document AOI submission syntax, config options, and shapefile requirements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R94-R103) [[2]](diffhunk://#diff-1b7ef935396ff0d592e61e984c0c785a5139754a8d875d90b088cc61f96cf7bdL8-R8) [[3]](diffhunk://#diff-1b7ef935396ff0d592e61e984c0c785a5139754a8d875d90b088cc61f96cf7bdR40-R53) [[4]](diffhunk://#diff-1b7ef935396ff0d592e61e984c0c785a5139754a8d875d90b088cc61f96cf7bdR76)

### Logging Improvements

* Enhanced inference logging to provide detailed progress and file information during model loading, inference, and GeoTIFF compression. [[1]](diffhunk://#diff-b73d153a995fe7bbc9122e0ef22eb223f0176b939172bb299bddc1ccd3c707a8R3) [[2]](diffhunk://#diff-b73d153a995fe7bbc9122e0ef22eb223f0176b939172bb299bddc1ccd3c707a8R15-R17) [[3]](diffhunk://#diff-b73d153a995fe7bbc9122e0ef22eb223f0176b939172bb299bddc1ccd3c707a8R62-R68) [[4]](diffhunk://#diff-b73d153a995fe7bbc9122e0ef22eb223f0176b939172bb299bddc1ccd3c707a8R90) [[5]](diffhunk://#diff-b73d153a995fe7bbc9122e0ef22eb223f0176b939172bb299bddc1ccd3c707a8R103) [[6]](diffhunk://#diff-066bdd73d91870ab210201494624609a97be1a0a0f2e4f2064f4e98b132738afR3)

### Utility and Validation Enhancements

* Improved runtime config validation for AOI paths and ensured proper path resolution for AOI files. [[1]](diffhunk://#diff-bc11fa91119882d71492381f5d23a3d4a9a7dcad6836f159d6c4bf6163fa4e19R167-R172) [[2]](diffhunk://#diff-bc11fa91119882d71492381f5d23a3d4a9a7dcad6836f159d6c4bf6163fa4e19R198-R199)
* Refactored patch info logging for multi-cutout runs to be reusable across grid and AOI submissions.

### Raster Data Handling

* Improved `scale_to_uint16` to robustly handle NaNs and floating-point data, ensuring safe conversion for geospatial outputs.